### PR TITLE
Navigation: use anchors

### DIFF
--- a/app/views/media_items/_media_item.html.erb
+++ b/app/views/media_items/_media_item.html.erb
@@ -3,7 +3,7 @@
     <%= link_to (local_assigns[:detail_view].present? ? media_item.photo : media_item) do %>
       <%= image_tag(
         (local_assigns[:detail_view].present? ? media_item.photo : media_item.photo.representation(resize_to_limit: [512, 512])),
-        class: 'media-item-img', alt: media_item.title) %>
+        class: 'media-item-img', alt: media_item.title, id: dom_id(media_item)) %>
     <% end %>
     <div class="card-body">
       <p class="card-text mb-0"><i class="bi bi-geo-alt"></i> <%= "#{media_item.waypoint.name}, #{media_item.waypoint.country_name} #{media_item.waypoint.country_flag}" %></p>

--- a/app/views/media_items/show.html.erb
+++ b/app/views/media_items/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/trips_header', trip: @media_item.trip, title: 'Media item', navbar: false %>
 
-<%= render 'shared/back_button', target: trip_media_items_path(@media_item.trip) %>
+<%= render 'shared/back_button', target: trip_media_items_path(@media_item.trip) + "\##{dom_id(@media_item)}" %>
 <% if can? :manage, @media_item %>
     <%= render 'shared/edit_button', target: edit_media_item_path(@media_item) %>
     <%= render 'shared/delete_button', target: media_item_path(@media_item) %>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -2,7 +2,7 @@
   <div class="card activity-card">
     <div class="card-body">
       <%= link_to post do %>
-        <h5 class="card-title"><%= post.title %></h5>
+        <h5 class="card-title" id="<%= dom_id(post) %>"><%= post.title %></h5>
       <% end %>
       <small class="text-muted">
         by <%= link_to_if can?(:show, post.user), post.user, post.user %><!--

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/trips_header', trip: @post.trip, title: 'Blog post', navbar: false %>
 
-<%= render 'shared/back_button', target: trip_posts_path(@post.trip) %>
+<%= render 'shared/back_button', target: trip_posts_path(@post.trip) + "#" + dom_id(@post) %>
 <% if can? :manage, @post %>
     <%= render 'shared/edit_button', target: edit_post_path(@post) %>
     <%= render 'shared/delete_button', target: post_path(@post) %>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/trips_header', trip: @post.trip, title: 'Blog post', navbar: false %>
 
-<%= render 'shared/back_button', target: trip_posts_path(@post.trip) + "#" + dom_id(@post) %>
+<%= render 'shared/back_button', target: trip_posts_path(@post.trip) + "\##{dom_id(@post)}" %>
 <% if can? :manage, @post %>
     <%= render 'shared/edit_button', target: edit_post_path(@post) %>
     <%= render 'shared/delete_button', target: post_path(@post) %>

--- a/app/views/segments/_segment.html.erb
+++ b/app/views/segments/_segment.html.erb
@@ -1,4 +1,4 @@
-<%= tag.tr class: class_names("segment-table-row-#{segment.status_string.downcase}") do %>
+<%= tag.tr class: class_names("segment-table-row-#{segment.status_string.downcase}"), id: dom_id(segment) do %>
   <th scope="row"><%= segment.sequence %></th>
   <td><%= link_to segment.waypoint_from.name, [@trip, segment] %></td>
   <td><%= link_to segment.waypoint_to.name, [@trip, segment] %></td>

--- a/app/views/segments/show.html.erb
+++ b/app/views/segments/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/trips_header', trip: @trip, title: 'Segment details', navbar: false %>
 
-<%= render 'shared/back_button', target: trip_segments_path(@trip) %>
+<%= render 'shared/back_button', target: trip_segments_path(@trip) + "\##{dom_id(@segment)}" %>
 <% if can? :manage, @segment %>
     <%= render 'shared/edit_button', target: edit_trip_segment_path(@trip, @segment) %>
     <%= render 'shared/delete_button', target: trip_segment_path(@trip, @segment) %>

--- a/app/views/waypoints/_waypoint.html.erb
+++ b/app/views/waypoints/_waypoint.html.erb
@@ -1,4 +1,4 @@
-<tr>
+<tr id="<%= dom_id(waypoint) %>">
   <th scope="row"><%= waypoint.sequence %></th>
   <td><%= link_to waypoint.name, [@trip, waypoint] %></td>
   <td class="d-none d-md-table-cell"><%= truncate_string(waypoint.notes) %></td>

--- a/app/views/waypoints/show.html.erb
+++ b/app/views/waypoints/show.html.erb
@@ -1,6 +1,6 @@
 <%= render 'shared/trips_header', trip: @trip, title: "Waypoint: #{@waypoint.name}", navbar: false %>
 
-<%= render 'shared/back_button', target: trip_waypoints_path(@trip) %>
+<%= render 'shared/back_button', target: trip_waypoints_path(@trip) + "\##{dom_id(@waypoint)}" %>
 <% if can? :manage, @waypoint %>
     <%= render 'shared/edit_button', target: edit_trip_waypoint_path(@trip, @waypoint) %>
     <%= render 'shared/delete_button', target: trip_waypoint_path(@trip, @waypoint),


### PR DESCRIPTION
Add id to detail records in index views for waypoints, segments, posts and media items. When navigating to a detail, the "back" button now includes the id (e.g. #post-2)

One problem that is still to solve: when the index page is paginated, the "back" button in the detail page also needs to consider the page.
Example: in the index, one is on page 2: url would be something like trips/1/posts?page=2
When opening a post, the back button currently points to trips/1/posts#post-2
But it should be trips/1/posts?page=2#post-2